### PR TITLE
Fixes s!triggered not working after API changes

### DIFF
--- a/src/commands/image-manipulation/triggered.js
+++ b/src/commands/image-manipulation/triggered.js
@@ -1,4 +1,5 @@
 const { Command } = require('../../')
+const snekfetch = require('snekfetch')
 
 module.exports = class Triggered extends Command {
   constructor (client) {
@@ -7,9 +8,10 @@ module.exports = class Triggered extends Command {
     this.aliases = ['trigger', 'puto']
   }
 
-  run (message) {
-    const user = message.mentions.users.first() || message.author
+  async run (message) {
     message.channel.startTyping()
-    message.channel.send({ file: { attachment: `http://www.triggered-api.tk/api/v2/triggered?url=${user.displayAvatarURL}`, name: 'triggered.gif' } }).then(() => message.channel.stopTyping())
+    const user = message.mentions.users.first() || message.author
+    const {body} = await snekfetch.get(`http://www.triggered-api.tk/api/v2/triggered?url=${user.displayAvatarURL}`).set({Authorization: process.env.TRIGGERED_TOKEN})
+    message.channel.send({ file: { attachment: body, name: 'triggered.gif' } }).then(() => message.channel.stopTyping())
   }
 }


### PR DESCRIPTION
Fixes #40

**Changes:**
`s!triggered` now requires the `TRIGGERED_TOKEN` environment variable to work.