### PR TITLE
stoptyping fix

### DIFF
--- a/src/commands/misc/stoptyping.js
+++ b/src/commands/misc/stoptyping.js
@@ -8,9 +8,9 @@ module.exports = class StopTyping extends Command {
   }
 
   run ({ t, author, channel }) {
-    const embed = new SwitchbladeEmbed(author)
-    channel.startTyping()
-    embed.setDescription(t('commands:stoptyping.tryingToStop'))
-    channel.send(embed).then(() => channel.stopTyping(true))
+    channel.stopTyping(true)
+    channel.send(
+      new SwitchbladeEmbed(author).setDescription(t('commands:stoptyping.tryingToStop'))
+    )
   }
 }


### PR DESCRIPTION
Currently, `s!stoptyping` actually starts typing and then stops typing. This PR fixes that.