### PR TITLE
Fixes MongoDB url parser deprecation

### DIFF
--- a/src/Switchblade.js
+++ b/src/Switchblade.js
@@ -28,7 +28,7 @@ module.exports = class Switchblade extends Client {
     this.listeners = []
     this.playerManager = null
 
-    this.initializeDatabase(MongoDB)
+    this.initializeDatabase(MongoDB, { useNewUrlParser: true })
     this.initializeApis('src/apis').then(() => {
       this.initializeListeners('src/listeners')
       this.downloadAndInitializeLocales('src/locales').then(() => {


### PR DESCRIPTION
- Fixes
`DeprecationWarning: current URL string parser is deprecated, and will be removed in a Future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.`