### PR TITLE
updating for owoifying locally instead of additional API call

### DIFF
--- a/src/commands/memes/owo.js
+++ b/src/commands/memes/owo.js
@@ -1,8 +1,7 @@
 const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
 const { Command, CommandParameters, StringParameter } = CommandStructures
 
-const snekfetch = require('snekfetch')
-const OWOapi = 'https://nekos.life/api/v2/owoify?text='
+const Owoify = require('../../utils/Owoify');
 
 module.exports = class OwO extends Command {
   constructor (client) {
@@ -15,15 +14,10 @@ module.exports = class OwO extends Command {
     )
   }
 
-  async run ({ t, author, channel }, text) {
+  async run ({ author, channel }, text) {
     const embed = new SwitchbladeEmbed(author)
     channel.startTyping()
-    const { body } = await snekfetch.get(OWOapi + encodeURIComponent(text))
-    if (body.msg) {
-      embed.setColor(Constants.ERROR_COLOR)
-        .setTitle(t('commands:owo.tooLongTitle'))
-        .setDescription(t('commands:owo.tooLongDescription'))
-    } else embed.setTitle(body.owo)
+    embed.setTitle(Owoify(text))
     channel.send(embed).then(() => channel.stopTyping())
   }
 }

--- a/src/utils/Owoify.js
+++ b/src/utils/Owoify.js
@@ -1,0 +1,12 @@
+function Owoify(str) {
+	str = str.replace(/(?:r|l)/g, "w")
+	str = str.replace(/(?:R|L)/g, "W")
+	str = str.replace(/n([aeiou])/g, 'ny$1')
+	str = str.replace(/N([aeiou])/g, 'Ny$1')
+	str = str.replace(/N([AEIOU])/g, 'Ny$1')
+	str = str.replace(/ove/g, "uv")
+
+	return str
+}
+
+module.exports = Owoify;


### PR DESCRIPTION
Closes #349 

Removed the API request to `nekos.life` and replaced with a local `Owoify` util to directly edit the input text 