### PR TITLE
Add the DEVELOPER_USERS variable for developers without roles

### DIFF
--- a/src/utils/PermissionUtils.js
+++ b/src/utils/PermissionUtils.js
@@ -2,7 +2,7 @@ module.exports = class PermissionUtils {
   static isDeveloper (client, user) {
     const botGuild = client.guilds.get(process.env.BOT_GUILD)
     const developerRole = botGuild && botGuild.roles.get(process.env.DEVELOPER_ROLE)
-    const isDeveloper = (developerRole && developerRole.members.has(user.id)) || (user.id === process.env.DEVELOPER_USER)
+    const isDeveloper = (developerRole && developerRole.members.has(user.id)) || (process.env.DEVELOPER_USERS.split(',').includes(user.id))
     return isDeveloper
   }
 

--- a/src/utils/PermissionUtils.js
+++ b/src/utils/PermissionUtils.js
@@ -2,7 +2,7 @@ module.exports = class PermissionUtils {
   static isDeveloper (client, user) {
     const botGuild = client.guilds.get(process.env.BOT_GUILD)
     const developerRole = botGuild && botGuild.roles.get(process.env.DEVELOPER_ROLE)
-    const isDeveloper = (developerRole && developerRole.members.has(user.id)) || (process.env.DEVELOPER_USERS.split(',').includes(user.id))
+    const isDeveloper = (developerRole && developerRole.members.has(user.id)) || (process.env.DEVELOPER_USERS && process.env.DEVELOPER_USERS.split(',').includes(user.id))
     return isDeveloper
   }
 

--- a/src/utils/PermissionUtils.js
+++ b/src/utils/PermissionUtils.js
@@ -2,8 +2,8 @@ module.exports = class PermissionUtils {
   static isDeveloper (client, user) {
     const botGuild = client.guilds.get(process.env.BOT_GUILD)
     const developerRole = botGuild && botGuild.roles.get(process.env.DEVELOPER_ROLE)
-    const hasRole = developerRole && developerRole.members.has(user.id)
-    return hasRole
+    const isDeveloper = (developerRole && developerRole.members.has(user.id)) || (user.id === process.env.DEVELOPER_USER)
+    return isDeveloper
   }
 
   static specialRole (client, user) {


### PR DESCRIPTION
Adds the `DEVELOPER_USER` variable, for setting a single developer instead of a role.