### PR TITLE
Adds the JoinLock command

### DIFF
--- a/src/Switchblade.js
+++ b/src/Switchblade.js
@@ -234,7 +234,7 @@ module.exports = class Switchblade extends Client {
 
       try {
         this.i18next.use(translationBackend).init({
-          ns: [ 'categories', 'commands', 'commons', 'errors', 'music', 'permissions', 'regions' ],
+          ns: [ 'categories', 'commands', 'commons', 'errors', 'music', 'permissions', 'regions', 'moderation' ],
           preload: await FileUtils.readdir(dirPath),
           fallbackLng: 'en-US',
           backend: {

--- a/src/commands/moderation/joinlock.js
+++ b/src/commands/moderation/joinlock.js
@@ -1,7 +1,7 @@
 const { CommandStructures, Constants, SwitchbladeEmbed } = require('../../')
 const { Command, CommandRequirements, CommandParameters, BooleanParameter } = CommandStructures
 
-module.exports = class Ban extends Command {
+module.exports = class JoinLock extends Command {
   constructor (client) {
     super(client)
     this.name = 'joinlock'

--- a/src/commands/moderation/joinlock.js
+++ b/src/commands/moderation/joinlock.js
@@ -8,8 +8,7 @@ module.exports = class Ban extends Command {
     this.aliases = ['jl']
     this.category = 'moderation'
 
-    // this.requirements = new CommandRequirements(this, { guildOnly: true, botPermissions: ['KICK_MEMBERS'], permissions: ['MANAGE_GUILD'] })
-    this.requirements = new CommandRequirements(this, { guildOnly: true })
+    this.requirements = new CommandRequirements(this, { guildOnly: true, botPermissions: ['KICK_MEMBERS'], permissions: ['MANAGE_GUILD'] })
     this.parameters = new CommandParameters(this,
       new BooleanParameter({ missingError: 'commands:joinlock.missingState' })
     )

--- a/src/commands/moderation/joinlock.js
+++ b/src/commands/moderation/joinlock.js
@@ -1,0 +1,30 @@
+const { CommandStructures, Constants, SwitchbladeEmbed } = require('../../')
+const { Command, CommandRequirements, CommandParameters, BooleanParameter } = CommandStructures
+
+module.exports = class Ban extends Command {
+  constructor (client) {
+    super(client)
+    this.name = 'joinlock'
+    this.aliases = ['jl']
+    this.category = 'moderation'
+
+    // this.requirements = new CommandRequirements(this, { guildOnly: true, botPermissions: ['KICK_MEMBERS'], permissions: ['MANAGE_GUILD'] })
+    this.requirements = new CommandRequirements(this, { guildOnly: true })
+    this.parameters = new CommandParameters(this,
+      new BooleanParameter({ missingError: 'commands:joinlock.missingState' })
+    )
+  }
+
+  async run ({ channel, guild, author, guildDocument, t }, newState) {
+    guildDocument = guildDocument || await this.client.database.guilds.get(guild.id)
+    const embed = new SwitchbladeEmbed(author)
+    if (guildDocument.joinLock === newState) {
+      embed.setColor(Constants.ERROR_COLOR).setTitle(t(`commands:joinlock.sameValue`, { context: newState.toString() }))
+    } else {
+      guildDocument.joinLock = newState
+      guildDocument.save()
+      embed.setTitle(`${newState ? '🔒' : '🔓'} ${t('commands:joinlock.success', { context: newState.toString() })}`)
+    }
+    channel.send(embed)
+  }
+}

--- a/src/database/mongo/Schemas.js
+++ b/src/database/mongo/Schemas.js
@@ -21,6 +21,8 @@ module.exports = {
   Guild: new Schema({
     _id: String,
     prefix: { type: String, default: process.env.PREFIX },
-    language: { type: String, default: 'en-US' }
+    language: { type: String, default: 'en-US' },
+    joinLock: { type: Boolean, default: false },
+    joinLockMessage: String
   })
 }

--- a/src/listeners/AutoModerator.js
+++ b/src/listeners/AutoModerator.js
@@ -8,11 +8,11 @@ module.exports = class MainListener extends EventListener {
 
   async onGuildMemberAdd (member) {
     const guildDocument = this.database && await this.database.guilds.findOne(member.guild.id)
-    const t = this.i18next.getFixedT(guildDocument.language)
     const guild = member.guild
 
     // TODO: Write a function to parse {placeholders} like the one used below
     if (guildDocument && guildDocument.joinLock && guild.me.hasPermission('KICK_MEMBERS') && member.kickable) {
+      const t = this.i18next.getFixedT(guildDocument.language)
       member.send(guildDocument.joinLockMessage ? guildDocument.joinLockMessage.replace('{server}', guild.name) : t('moderation:joinLock.defaultPrivateMessage', { guild })).catch(() => {})
       member.kick(t('moderation:joinLock.kickReason'))
     }

--- a/src/listeners/AutoModerator.js
+++ b/src/listeners/AutoModerator.js
@@ -1,0 +1,16 @@
+const { EventListener } = require('../')
+
+module.exports = class MainListener extends EventListener {
+  constructor (client) {
+    super(client)
+    this.events = ['guildMemberAdd']
+  }
+
+  async onGuildMemberAdd (member) {
+    const guildDocument = this.database && await this.database.guilds.findOne(member.guild.id)
+    const t = this.i18next.getFixedT(guildDocument.language)
+
+    // Join Lock
+    if (guildDocument && guildDocument.joinLock && member.guild.me.hasPermission('KICK_MEMBERS') && member.kickable) member.kick(t('moderation:reasons.joinLockEnabled'))
+  }
+}

--- a/src/listeners/AutoModerator.js
+++ b/src/listeners/AutoModerator.js
@@ -13,7 +13,7 @@ module.exports = class MainListener extends EventListener {
 
     // TODO: Write a function to parse {placeholders} like the one used below
     if (guildDocument && guildDocument.joinLock && guild.me.hasPermission('KICK_MEMBERS') && member.kickable) {
-      member.send(guildDocument.joinLockMessage && guildDocument.joinLockMessage.replace('{server}', guild.name) || t('moderation:joinLock.defaultPrivateMessage', {guild})).catch(() => {})
+      member.send(guildDocument.joinLockMessage ? guildDocument.joinLockMessage.replace('{server}', guild.name) : t('moderation:joinLock.defaultPrivateMessage', { guild })).catch(() => {})
       member.kick(t('moderation:joinLock.kickReason'))
     }
   }

--- a/src/listeners/AutoModerator.js
+++ b/src/listeners/AutoModerator.js
@@ -9,8 +9,12 @@ module.exports = class MainListener extends EventListener {
   async onGuildMemberAdd (member) {
     const guildDocument = this.database && await this.database.guilds.findOne(member.guild.id)
     const t = this.i18next.getFixedT(guildDocument.language)
+    const guild = member.guild
 
-    // Join Lock
-    if (guildDocument && guildDocument.joinLock && member.guild.me.hasPermission('KICK_MEMBERS') && member.kickable) member.kick(t('moderation:reasons.joinLockEnabled'))
+    // TODO: Write a function to parse {placeholders} like the one used below
+    if (guildDocument && guildDocument.joinLock && guild.me.hasPermission('KICK_MEMBERS') && member.kickable) {
+      member.send(guildDocument.joinLockMessage && guildDocument.joinLockMessage.replace('{server}', guild.name) || t('moderation:joinLock.defaultPrivateMessage', {guild})).catch(() => {})
+      member.kick(t('moderation:joinLock.kickReason'))
+    }
   }
 }

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -691,5 +691,13 @@
     "commandDescription": "Shows the current rate of a currency or a pair.",
     "commandUsage": "<to> [from] [value]",
     "noCurrency": "You have to give me a valid currency or a pair."
+  },
+  "joinlock": {
+    "commandDescription": "Enables or disables the join lock",
+    "commandUsage": "<on|off>",
+    "sameValue_true": "The join lock is already enabled.",
+    "sameValue_false": "The join lock is already disabled.",
+    "success_true": "Join lock enabled.",
+    "success_false": "Join lock disabled."
   }
 }

--- a/src/locales/en-US/moderation.json
+++ b/src/locales/en-US/moderation.json
@@ -1,0 +1,5 @@
+{
+  "reasons": {
+    "joinLockEnabled": "Join lock is enabled"
+  }
+}

--- a/src/locales/en-US/moderation.json
+++ b/src/locales/en-US/moderation.json
@@ -1,5 +1,6 @@
 {
-  "reasons": {
-    "joinLockEnabled": "Join lock is enabled"
+  "joinLock": {
+    "defaultPrivateMessage": "You've been kicked from **{{guild.name}}** because the join lock is enabled. Please try joining again later.",
+    "kickReason": "Join lock is enabled"
   }
 }

--- a/src/structures/command/index.js
+++ b/src/structures/command/index.js
@@ -7,6 +7,7 @@ module.exports = {
   // Parameters
   Parameter: require('./parameters/types/Parameter.js'),
   BooleanFlagParameter: require('./parameters/types/BooleanFlagParameter.js'),
+  BooleanParameter: require('./parameters/types/BooleanParameter.js'),
   ColorParameter: require('./parameters/types/ColorParameter.js'),
   MemberParameter: require('./parameters/types/MemberParameter.js'),
   NumberParameter: require('./parameters/types/NumberParameter.js'),

--- a/src/structures/command/parameters/types/BooleanParameter.js
+++ b/src/structures/command/parameters/types/BooleanParameter.js
@@ -1,0 +1,15 @@
+const Parameter = require('./Parameter.js')
+const CommandError = require('../../CommandError.js')
+
+module.exports = class StringParameter extends Parameter {
+  constructor (options = {}) {
+    super(options)
+    this.trueValues = options.trueValues || ['true', 'yes', 'on']
+    this.falseValues = options.falseValues || ['false', 'no', 'off']
+  }
+
+  parse (arg) {
+    if (!this.trueValues.concat(this.falseValues).includes(arg)) return new CommandError(t('errors:notTrueOrFalse'))
+    return this.trueValues.includes(arg)
+  }
+}

--- a/src/structures/command/parameters/types/BooleanParameter.js
+++ b/src/structures/command/parameters/types/BooleanParameter.js
@@ -8,7 +8,7 @@ module.exports = class StringParameter extends Parameter {
     this.falseValues = options.falseValues || ['false', 'no', 'off']
   }
 
-  parse (arg) {
+  parse (arg, {t}) {
     if (!this.trueValues.concat(this.falseValues).includes(arg)) return new CommandError(t('errors:notTrueOrFalse'))
     return this.trueValues.includes(arg)
   }

--- a/src/structures/command/parameters/types/BooleanParameter.js
+++ b/src/structures/command/parameters/types/BooleanParameter.js
@@ -8,7 +8,7 @@ module.exports = class StringParameter extends Parameter {
     this.falseValues = options.falseValues || ['false', 'no', 'off']
   }
 
-  parse (arg, {t}) {
+  parse (arg, { t }) {
     if (!this.trueValues.concat(this.falseValues).includes(arg)) return new CommandError(t('errors:notTrueOrFalse'))
     return this.trueValues.includes(arg)
   }


### PR DESCRIPTION
`s!joinlock <on|off>` - Enables or disables the join lock. When the join lock is enabled, new members are automatically kicked upon join.

**`[!]`** The `joinLockMessage` exists for a custom private message, but there is currently no way to set it through the bot. This is to be used with the future dashboard.

Closes #525 