### PR TITLE
Fixes Translation Manager permission bug

### DIFF
--- a/src/utils/PermissionUtils.js
+++ b/src/utils/PermissionUtils.js
@@ -16,9 +16,8 @@ module.exports = class PermissionUtils {
 
   static isManager (client, user) {
     const botGuild = client.guilds.get(process.env.BOT_GUILD)
-    const developerRole = botGuild && botGuild.roles.get(process.env.DEVELOPER_ROLE)
     const managerRole = botGuild && botGuild.roles.get(process.env.MANAGER_ROLE)
-    const isManager = (managerRole && managerRole.members.has(user.id)) || (developerRole && developerRole.members.has(user.id))
+    const isManager = (managerRole && managerRole.members.has(user.id)) || this.isDeveloper(client.user)
     return isManager
   }
 }

--- a/src/utils/PermissionUtils.js
+++ b/src/utils/PermissionUtils.js
@@ -17,7 +17,7 @@ module.exports = class PermissionUtils {
   static isManager (client, user) {
     const botGuild = client.guilds.get(process.env.BOT_GUILD)
     const managerRole = botGuild && botGuild.roles.get(process.env.MANAGER_ROLE)
-    const isManager = (managerRole && managerRole.members.has(user.id)) || this.isDeveloper(client.user)
+    const isManager = (managerRole && managerRole.members.has(user.id)) || this.isDeveloper(client, user)
     return isManager
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the bot wouldn't let you run `s!reloadlocales` when you were set as a developer using `DEVELOPER_USERS`.

![image](https://user-images.githubusercontent.com/25179120/50623342-79834a80-0ef3-11e9-83aa-abbc1cabfe9f.png)

(the fix was so simple I didn't even bother opening an issue for this bug)