### PR TITLE
Exit when websocket fails

### DIFF
--- a/src/listeners/ExitOnWebSocketError.js
+++ b/src/listeners/ExitOnWebSocketError.js
@@ -1,0 +1,12 @@
+const { EventListener } = require('../')
+
+module.exports = class MainListener extends EventListener {
+  constructor (client) {
+    super(client)
+    this.events = ['error']
+  }
+
+  async onError () {
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Currently, when the WebSocket loses connection, it just throws an ErrorLog error and nothing happens. If we kill the process, the process manager will restart it and the bot will get up again.