### PR TITLE
Subcommands in separated files

### DIFF
--- a/src/Switchblade.js
+++ b/src/Switchblade.js
@@ -33,6 +33,8 @@ module.exports = class Switchblade extends Client {
         })
       })
     })
+
+    this.posLoadCommands = []
   }
 
   /**
@@ -74,34 +76,72 @@ module.exports = class Switchblade extends Client {
    * @param {Command} command - Command to be added
    */
   addCommand (command) {
+    const check = this.checkCommand(command)
+    if (!check) return check
+
+    if (typeof command.parentCommand === 'string' || Array.isArray(command.parentCommand)) {
+      this.posLoadCommands.push(command)
+    } else {
+      this.commands.push(command)
+    }
+
+    return check
+  }
+
+  addSubcommand (subCommand) {
+    const check = this.checkCommand(subCommand)
+    if (!check) return check
+
+    let parentCommand
+    if (typeof subCommand.parentCommand === 'string') {
+      parentCommand = this.commands.find(c => c.name === subCommand.parentCommand)
+    } else if (Array.isArray(subCommand.parentCommand)) {
+      parentCommand = subcommand.parentCommand.reduce((o, ca) => {
+        const arr = (Array.isArray(o) && o) || (o && o.subcommands)
+        if (!arr) return
+        return arr.find(c => c.name === ca)
+      }, this.commands)
+    }
+
+    if (parentCommand) {
+      parentCommand.subcommands.push(subCommand)
+      subCommand.parentCommand = parentCommand
+    } else {
+      this.log(`[31m${parentCommand.fullName} failed to load - Couldn't find parent command.`, 'Commands')
+      return false
+    }
+
+    return check
+  }
+
+  checkCommand (command) {
     if (!(command instanceof Command)) {
       this.log(`[31m${command} failed to load - Not a command`, 'Commands')
       return false
     }
 
     if (command.canLoad() !== true) {
-      this.log(`[31m${command.name} failed to load - ${command.canLoad() || 'canLoad function did not return true.'}`, 'Commands')
+      this.log(`[31m${command.fullName} failed to load - ${command.canLoad() || 'canLoad function did not return true.'}`, 'Commands')
       return false
     }
 
     if (command.requirements) {
       if (!command.requirements.apis.every(api => {
-        if (!this.apis[api]) this.log(`[31m${command.name} failed to load - Required API wrapper "${api}" not found.`, 'Commands')
+        if (!this.apis[api]) this.log(`[31m${command.fullName} failed to load - Required API wrapper "${api}" not found.`, 'Commands')
         return !!this.apis[api]
       })) return false
 
       if (!command.requirements.envVars.every(variable => {
-        if (!process.env[variable]) this.log(`[31m${command.name} failed to load - Required environment variable "${variable}" is not set.`, 'Commands')
+        if (!process.env[variable]) this.log(`[31m${command.fullName} failed to load - Required environment variable "${variable}" is not set.`, 'Commands')
         return !!process.env[variable]
       })) return false
 
       if (command.requirements.canvasOnly && !this.canvasLoaded) {
-        this.log(`[31m${command.name} failed to load - Canvas is not installed.`, 'Commands')
+        this.log(`[31m${command.fullName} failed to load - Canvas is not installed.`, 'Commands')
         return false
       }
     }
 
-    this.commands.push(command)
     return true
   }
 
@@ -125,9 +165,10 @@ module.exports = class Switchblade extends Client {
     let success = 0
     let failed = 0
     FileUtils.requireDirectory(dirPath, (NewCommand) => {
-      if (NewCommand.ignore) return
       this.addCommand(new NewCommand(this)) ? success++ : failed++
     }, this.logError).then(() => {
+      const sorted = this.posLoadCommands.sort((a, b) => +(typeof b === 'string') || -(typeof a === 'string') || a.length - b.length)
+      sorted.forEach(subCommand => this.addSubcommand(subCommand))
       this.log(failed ? `[33m${success} commands loaded, ${failed} failed.` : `[32mAll ${success} commands loaded without errors.`, 'Commands')
     }).catch(this.logError)
   }

--- a/src/Switchblade.js
+++ b/src/Switchblade.js
@@ -96,7 +96,7 @@ module.exports = class Switchblade extends Client {
     if (typeof subCommand.parentCommand === 'string') {
       parentCommand = this.commands.find(c => c.name === subCommand.parentCommand)
     } else if (Array.isArray(subCommand.parentCommand)) {
-      parentCommand = subcommand.parentCommand.reduce((o, ca) => {
+      parentCommand = subCommand.parentCommand.reduce((o, ca) => {
         const arr = (Array.isArray(o) && o) || (o && o.subcommands)
         if (!arr) return
         return arr.find(c => c.name === ca)

--- a/src/commands/configuration/config.js
+++ b/src/commands/configuration/config.js
@@ -1,10 +1,5 @@
-const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
-const { Command, CommandParameters, CommandRequirements, StringParameter } = CommandStructures
-
-const i18next = require('i18next')
-
-const languageCodes = () => Object.keys(i18next.store.data)
-const languageAliases = (cli) => Object.values(cli.cldr.languages).map(v => Object.values(v)).reduce((a, v) => a.concat(v), []).reduce((a, v) => a.concat(v), [])
+const { CommandStructures, SwitchbladeEmbed } = require('../../')
+const { Command, CommandRequirements } = CommandStructures
 
 module.exports = class Config extends Command {
   constructor (client) {
@@ -12,7 +7,6 @@ module.exports = class Config extends Command {
     this.name = 'config'
     this.aliases = ['cfg']
     this.category = 'configuration'
-    this.subcommands = [new ConfigLanguage(client, this), new ConfigPrefix(client, this)]
 
     this.requirements = new CommandRequirements(this, { guildOnly: true, databaseOnly: true, permissions: ['MANAGE_GUILD'] })
   }
@@ -23,83 +17,6 @@ module.exports = class Config extends Command {
       t('commands:config.guildPrefix', { command: `${prefix}${alias || this.name}` }),
       t('commands:config.guildLang', { command: `${prefix}${alias || this.name}` })
     ].join('\n'))
-    channel.send(embed)
-  }
-}
-
-class ConfigLanguage extends Command {
-  constructor (client, parentCommand) {
-    super(client, parentCommand)
-    this.name = 'language'
-    this.aliases = ['lang']
-
-    this.parameters = new CommandParameters(this,
-      new StringParameter({
-        full: true,
-        whitelist: (arg) => languageCodes().concat(languageAliases(this.client)).some(l => l.toLowerCase() === arg.toLowerCase()),
-        missingError: ({ t, prefix }) => {
-          return {
-            title: t('commands:config.subcommands.language.noCode'),
-            description: [
-              `**${t('commons:usage')}:** \`${prefix}${parentCommand.name} ${this.name} ${t('commands:config.subcommands.language.commandUsage')}\``,
-              '',
-              `__**${t('commands:config.subcommands.language.availableLanguages')}:**__`,
-              `**${languageCodes().map(l => `\`${l}\``).join(', ')}**`,
-              '',
-              `${t('commands:config.missingTranslation')}`
-            ].join('\n')
-          }
-        } })
-    )
-  }
-
-  async run ({ t, author, channel, guild }, lang) {
-    lang = lang.toLowerCase()
-    const langCodes = languageCodes()
-    const langDisplayNames = this.client.cldr.languages
-    if (!langCodes.some(l => l.toLowerCase() === lang)) {
-      lang = langCodes.find(lc => langDisplayNames[lc] && Object.values(langDisplayNames[lc]).reduce((a, v) => a.concat(v), []).includes(lang))
-    }
-
-    lang = langCodes.find(l => l.toLowerCase() === lang.toLowerCase())
-    const language = langDisplayNames[lang] && langDisplayNames[lang][lang]
-    const langDisplayName = language && language[0]
-
-    const embed = new SwitchbladeEmbed(author)
-
-    try {
-      await this.client.modules.configuration.setLanguage(guild.id, lang)
-      embed.setTitle(i18next.getFixedT(lang)('commands:config.subcommands.language.changedSuccessfully', { lang: langDisplayName || lang }))
-    } catch (e) {
-      embed.setColor(Constants.ERROR_COLOR)
-        .setTitle(t('errors:generic'))
-    }
-
-    channel.send(embed)
-  }
-}
-
-class ConfigPrefix extends Command {
-  constructor (client, parentCommand) {
-    super(client, parentCommand)
-    this.name = 'prefix'
-
-    this.parameters = new CommandParameters(this,
-      new StringParameter({ full: true, required: false, missingError: 'commands:config.subcommands.prefix.noPrefix' })
-    )
-  }
-
-  async run ({ t, author, channel, guild }, prefix = process.env.PREFIX) {
-    const embed = new SwitchbladeEmbed(author)
-
-    try {
-      await this.client.modules.configuration.setPrefix(guild.id, prefix)
-      embed.setTitle(t('commands:config.subcommands.prefix.changedSuccessfully', { prefix }))
-    } catch (e) {
-      embed.setColor(Constants.ERROR_COLOR)
-        .setTitle(t('errors:generic'))
-    }
-
     channel.send(embed)
   }
 }

--- a/src/commands/configuration/language.js
+++ b/src/commands/configuration/language.js
@@ -1,0 +1,60 @@
+const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
+const { Command, CommandParameters, StringParameter } = CommandStructures
+
+const i18next = require('i18next')
+
+const languageCodes = () => Object.keys(i18next.store.data)
+const languageAliases = (cli) => Object.values(cli.cldr.languages).map(v => Object.values(v)).reduce((a, v) => a.concat(v), []).reduce((a, v) => a.concat(v), [])
+
+module.exports = class ConfigLanguage extends Command {
+  constructor (client, parentCommand) {
+    super(client, parentCommand || 'config')
+    this.name = 'language'
+    this.aliases = ['lang']
+
+    this.parameters = new CommandParameters(this,
+      new StringParameter({
+        full: true,
+        whitelist: (arg) => languageCodes().concat(languageAliases(this.client)).some(l => l.toLowerCase() === arg.toLowerCase()),
+        missingError: ({ t, prefix }) => {
+          return {
+            title: t('commands:config.subcommands.language.noCode'),
+            description: [
+              `**${t('commons:usage')}:** \`${prefix}${parentCommand.name} ${this.name} ${t('commands:config.subcommands.language.commandUsage')}\``,
+              '',
+              `__**${t('commands:config.subcommands.language.availableLanguages')}:**__`,
+              `**${languageCodes().map(l => `\`${l}\``).join(', ')}**`,
+              '',
+              `${t('commands:config.missingTranslation')}`
+            ].join('\n')
+          }
+        } })
+    )
+  }
+
+  async run ({ t, author, channel, guild }, lang) {
+    lang = lang.toLowerCase()
+    const langCodes = languageCodes()
+    const langDisplayNames = this.client.cldr.languages
+    if (!langCodes.some(l => l.toLowerCase() === lang)) {
+      lang = langCodes.find(lc => langDisplayNames[lc] && Object.values(langDisplayNames[lc]).reduce((a, v) => a.concat(v), []).includes(lang))
+    }
+
+    lang = langCodes.find(l => l.toLowerCase() === lang.toLowerCase())
+    const language = langDisplayNames[lang] && langDisplayNames[lang][lang]
+    const langDisplayName = language && language[0]
+
+    const embed = new SwitchbladeEmbed(author)
+
+    try {
+      await this.client.modules.configuration.setLanguage(guild.id, lang)
+      embed.setTitle(i18next.getFixedT(lang)('commands:config.subcommands.language.changedSuccessfully', { lang: langDisplayName || lang }))
+    } catch (e) {
+      embed.setColor(Constants.ERROR_COLOR)
+        .setTitle(t('errors:generic'))
+    }
+
+    channel.send(embed)
+  }
+
+}

--- a/src/commands/configuration/language.js
+++ b/src/commands/configuration/language.js
@@ -20,7 +20,7 @@ module.exports = class ConfigLanguage extends Command {
           return {
             title: t('commands:config.subcommands.language.noCode'),
             description: [
-              `**${t('commons:usage')}:** \`${prefix}${parentCommand.name} ${this.name} ${t('commands:config.subcommands.language.commandUsage')}\``,
+              this.usage(t, prefix),
               '',
               `__**${t('commands:config.subcommands.language.availableLanguages')}:**__`,
               `**${languageCodes().map(l => `\`${l}\``).join(', ')}**`,
@@ -56,5 +56,4 @@ module.exports = class ConfigLanguage extends Command {
 
     channel.send(embed)
   }
-
 }

--- a/src/commands/configuration/prefix.js
+++ b/src/commands/configuration/prefix.js
@@ -1,0 +1,27 @@
+const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
+const { Command, CommandParameters, StringParameter } = CommandStructures
+
+module.exports = class ConfigPrefix extends Command {
+  constructor (client, parentCommand) {
+    super(client, parentCommand || 'config')
+    this.name = 'prefix'
+
+    this.parameters = new CommandParameters(this,
+      new StringParameter({ full: true, required: false, missingError: 'commands:config.subcommands.prefix.noPrefix' })
+    )
+  }
+
+  async run ({ t, author, channel, guild }, prefix = process.env.PREFIX) {
+    const embed = new SwitchbladeEmbed(author)
+
+    try {
+      await this.client.modules.configuration.setPrefix(guild.id, prefix)
+      embed.setTitle(t('commands:config.subcommands.prefix.changedSuccessfully', { prefix }))
+    } catch (e) {
+      embed.setColor(Constants.ERROR_COLOR)
+        .setTitle(t('errors:generic'))
+    }
+
+    channel.send(embed)
+  }
+}

--- a/src/test/commands.js
+++ b/src/test/commands.js
@@ -4,17 +4,16 @@ const MiscUtils = require('../utils/MiscUtils.js')
 const commands = []
 
 FileUtils.requireDirectory('src/commands', (NewCommand) => {
-  if (NewCommand.ignore) return
   commands.push(NewCommand)
 }, console.error).catch(console.error)
 
 describe('Commands', () => {
   it('should have no duplicate names or aliases', (done) => {
-    let aliases = []
-    commands.forEach(NewCommand => {
-      aliases = aliases.concat(new NewCommand().aliases)
-    })
-    const dupes = MiscUtils.findArrayDuplicates(commands.map(CurrentCommand => new CurrentCommand().name).concat(aliases))
+    const aliases = commands.reduce((arr, NewCommand) => {
+      const { name, aliases } = new NewCommand()
+      return [ ...arr, name, ...aliases ]
+    }, [])
+    const dupes = MiscUtils.findArrayDuplicates(aliases)
     if (dupes.length) {
       done(new Error(`The following names or aliases were found more than once: ${dupes.join(', ')}`))
     } else {
@@ -33,28 +32,49 @@ describe('Commands', () => {
   })
 
   it('should be in commands.json', (done) => {
-    let notInCommandsFile = []
     const commandsFile = require('../../src/locales/en-US/commands.json')
-    commands.forEach(CurrentCommand => {
-      const name = new CurrentCommand().name
-      if (!commandsFile[name]) notInCommandsFile.push(name)
+    const notInCommandsFile = commands.map(CurrentCommand => new CurrentCommand()).filter(command => {
+      const { name, parentCommand } = command
+      if (parentCommand) {
+        if (typeof parentCommand === 'string') {
+          const parentSubcommands = commandsFile[parentCommand] && commandsFile[parentCommand].subcommands
+          return !(parentSubcommands && parentSubcommands[name])
+        } else if (Array.isArray(parentCommand)) {
+          return !parentCommand.reduce((o, ca) => {
+            if (o === undefined) return commandsFile[ca] || false
+            return o.subcommands && o.subcommands[ca]
+          })
+        }
+      }
+      return !commandsFile[name]
     })
     if (notInCommandsFile.length) {
-      done(new Error(`The following commands are not in commands.json: ${notInCommandsFile.join(', ')}`))
+      done(new Error(`The following commands are not in commands.json: ${notInCommandsFile.map(c => c.name).join(', ')}`))
     } else {
       done()
     }
   })
 
   it('should have descriptions', (done) => {
-    let noDescription = []
     const commandsFile = require('../../src/locales/en-US/commands.json')
-    commands.forEach(CurrentCommand => {
-      const name = new CurrentCommand().name
-      if (!commandsFile[name] || !commandsFile[name]['commandDescription']) noDescription.push(name)
+    const noDescription = commands.map(CurrentCommand => new CurrentCommand()).filter(command => {
+      const { name, parentCommand } = command
+      if (parentCommand) {
+        if (typeof parentCommand === 'string') {
+          const parentSubcommands = commandsFile[parentCommand] && commandsFile[parentCommand].subcommands
+          return !(parentSubcommands && parentSubcommands[name] && parentSubcommands[name].commandDescription)
+        } else if (Array.isArray(parentCommand)) {
+          const finalCommand = parentCommand.reduce((o, ca) => {
+            if (o === undefined) return commandsFile[ca] || false
+            return o.subcommands && o.subcommands[ca]
+          })
+          return !(finalCommand && finalCommand.commandDescription)
+        }
+      }
+      return !(commandsFile[name] && commandsFile[name].commandDescription)
     })
     if (noDescription.length) {
-      done(new Error(`The following commands don't have descriptions: ${noDescription.join(', ')}`))
+      done(new Error(`The following commands don't have descriptions: ${noDescription.map(c => c.name).join(', ')}`))
     } else {
       done()
     }


### PR DESCRIPTION
### Example
#### `s!cmd a b c`
- In the `cmd` class there's no parentCommand
- In the `a` class, `parentCommand` is going to be `'cmd'`
- In the `b` class, `parentCommand` is going to be `['cmd', 'a']`
- In the `c` class, `parentCommand` is going to be `['cmd', 'a', 'b']`

###### Closes #205 