### PR TITLE
Fix Listener class naming

### DIFF
--- a/src/listeners/AutoModerator.js
+++ b/src/listeners/AutoModerator.js
@@ -1,6 +1,6 @@
 const { EventListener } = require('../')
 
-module.exports = class MainListener extends EventListener {
+module.exports = class AutoModerator extends EventListener {
   constructor (client) {
     super(client)
     this.events = ['guildMemberAdd']

--- a/src/listeners/ExitOnWebSocketError.js
+++ b/src/listeners/ExitOnWebSocketError.js
@@ -1,6 +1,6 @@
 const { EventListener } = require('../')
 
-module.exports = class MainListener extends EventListener {
+module.exports = class ExitOnWebSocketError extends EventListener {
   constructor (client) {
     super(client)
     this.events = ['error']


### PR DESCRIPTION
Changes the listeners class names. All of them were using `MainListener`