### PR TITLE
Command Cleanup + Enchancements

### DIFF
--- a/src/commands/bot/botinfo.js
+++ b/src/commands/bot/botinfo.js
@@ -11,25 +11,23 @@ module.exports = class BotInfo extends Command {
   }
 
   run ({ channel, author, t }) {
-    const embed = new SwitchbladeEmbed(author)
     const uptime = moment.duration(process.uptime() * 1000).format('d[d] h[h] m[m] s[s]')
-    channel.startTyping()
-
-    embed.setAuthor(this.client.user.username, this.client.user.displayAvatarURL)
-      .setThumbnail(this.client.user.displayAvatarURL)
-      .setDescription([
-        t('commands:botinfo.hello', { user: this.client.user }),
-        t('commands:botinfo.statistics', { guilds: this.client.guilds, commands: this.client.commands, uptime, Discord, nodeVersion: process.version, users: this.client.users.filter(u => !u.bot).size })
-      ].join('\n\n'))
-      .addField(t('commands:botinfo.links'), [
-        t('commands:botinfo.inviteLink', { Constants }),
-        t('commands:botinfo.supportServer', { Constants }),
-        t('commands:botinfo.website', { Constants }),
-        t('commands:botinfo.translate', { Constants }),
-        t('commands:botinfo.github', { Constants }),
-        t('commands:botinfo.patreon', { Constants })
-      ].join('\n'))
-
-    channel.send(embed).then(() => channel.stopTyping())
+    channel.send(
+      new SwitchbladeEmbed(author)
+        .setAuthor(this.client.user.username, this.client.user.displayAvatarURL)
+        .setThumbnail(this.client.user.displayAvatarURL)
+        .setDescription([
+          t('commands:botinfo.hello', { user: this.client.user }),
+          t('commands:botinfo.statistics', { guilds: this.client.guilds, commands: this.client.commands, uptime, Discord, nodeVersion: process.version, users: this.client.users.filter(u => !u.bot).size })
+        ].join('\n\n'))
+        .addField(t('commands:botinfo.links'), [
+          t('commands:botinfo.inviteLink', { Constants }),
+          t('commands:botinfo.supportServer', { Constants }),
+          t('commands:botinfo.website', { Constants }),
+          t('commands:botinfo.translate', { Constants }),
+          t('commands:botinfo.github', { Constants }),
+          t('commands:botinfo.patreon', { Constants })
+        ].join('\n'))
+    )
   }
 }

--- a/src/commands/bot/dbl.js
+++ b/src/commands/bot/dbl.js
@@ -11,7 +11,7 @@ module.exports = class DBL extends Command {
     this.requirements = new CommandRequirements(this, { databaseOnly: true, apis: ['dbl'] })
   }
 
-  async run ({ t, author, channel, prefix, alias, userDocument }) {
+  async run ({ t, author, channel, prefix, alias }) {
     const embed = new SwitchbladeEmbed(author)
     channel.startTyping()
 

--- a/src/commands/bot/i18n.js
+++ b/src/commands/bot/i18n.js
@@ -9,11 +9,10 @@ module.exports = class i18n extends Command {
   }
 
   async run ({ t, channel }) {
-    const embed = new SwitchbladeEmbed()
-    channel.startTyping()
-    embed
-      .setDescription(`${Constants.CROWDIN_LOGO} ${t('commands:i18n.TranslateMe')}`)
-      .setImage('https://i.imgur.com/UVIAzg0.gif')
-    channel.send(embed).then(() => channel.stopTyping())
+    channel.send(
+      new SwitchbladeEmbed()
+        .setDescription(`${Constants.CROWDIN_LOGO} ${t('commands:i18n.TranslateMe')}`)
+        .setImage('https://i.imgur.com/UVIAzg0.gif')
+    )
   }
 }

--- a/src/commands/bot/invite.js
+++ b/src/commands/bot/invite.js
@@ -8,11 +8,12 @@ module.exports = class Invite extends Command {
   }
 
   async run ({ t, channel }) {
-    const embed = new SwitchbladeEmbed()
     channel.startTyping()
     const invite = await this.client.generateInvite()
-    embed.setThumbnail(this.client.user.displayAvatarURL)
-      .setDescription(`[${t('commands:invite.clickHere')}](${invite})\n${t('commands:invite.noteThat')}`)
-    channel.send(embed).then(() => channel.stopTyping())
+    channel.send(
+      new SwitchbladeEmbed()
+        .setThumbnail(this.client.user.displayAvatarURL)
+        .setDescription(`[${t('commands:invite.clickHere')}](${invite})\n${t('commands:invite.noteThat')}`)
+    ).then(() => {channel.stopTyping()})
   }
 }

--- a/src/commands/configuration/config.js
+++ b/src/commands/configuration/config.js
@@ -1,5 +1,5 @@
-const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
-const { Command, CommandParameters, CommandRequirements, StringParameter } = CommandStructures
+const { CommandStructures, SwitchbladeEmbed } = require('../../')
+const { Command, CommandParameters, CommandRequirements, StringParameter, CommandError } = CommandStructures
 
 const i18next = require('i18next')
 
@@ -18,12 +18,13 @@ module.exports = class Config extends Command {
   }
 
   run ({ t, author, prefix, alias, channel }) {
-    const embed = new SwitchbladeEmbed(author)
-    embed.setDescription([
-      t('commands:config.guildPrefix', { command: `${prefix}${alias || this.name}` }),
-      t('commands:config.guildLang', { command: `${prefix}${alias || this.name}` })
-    ].join('\n'))
-    channel.send(embed)
+    channel.send(
+      new SwitchbladeEmbed(author)
+        .setDescription([
+          t('commands:config.guildPrefix', { command: `${prefix}${alias || this.name}` }),
+          t('commands:config.guildLang', { command: `${prefix}${alias || this.name}` })
+        ].join('\n'))
+    )
   }
 }
 
@@ -47,6 +48,7 @@ class ConfigLanguage extends Command {
               '',
               `${t('commands:config.missingTranslation')}`
             ].join('\n'))
+            .setFooter(author.tag)
         }
       })
     )
@@ -64,17 +66,15 @@ class ConfigLanguage extends Command {
     const language = langDisplayNames[lang] && langDisplayNames[lang][lang]
     const langDisplayName = language && language[0]
 
-    const embed = new SwitchbladeEmbed(author)
-
     try {
       await this.client.modules.configuration.setLanguage(guild.id, lang)
-      embed.setTitle(i18next.getFixedT(lang)('commands:config.subcommands.language.changedSuccessfully', { lang: langDisplayName || lang }))
+      channel.send(
+        new SwitchbladeEmbed(author)
+          .setTitle(i18next.getFixedT(lang)('commands:config.subcommands.language.changedSuccessfully', { lang: langDisplayName || lang }))
+      )
     } catch (e) {
-      embed.setColor(Constants.ERROR_COLOR)
-        .setTitle(t('errors:generic'))
+      throw new CommandError(t('errors:generic'))
     }
-
-    channel.send(embed)
   }
 }
 
@@ -89,16 +89,14 @@ class ConfigPrefix extends Command {
   }
 
   async run ({ t, author, channel, guild }, prefix = process.env.PREFIX) {
-    const embed = new SwitchbladeEmbed(author)
-
     try {
       await this.client.modules.configuration.setPrefix(guild.id, prefix)
-      embed.setTitle(t('commands:config.subcommands.prefix.changedSuccessfully', { prefix }))
+      channel.send(
+        new SwitchbladeEmbed(author)
+          .setTitle(t('commands:config.subcommands.prefix.changedSuccessfully', { prefix }))
+      )
     } catch (e) {
-      embed.setColor(Constants.ERROR_COLOR)
-        .setTitle(t('errors:generic'))
+      throw new CommandError(t('errors:generic'))
     }
-
-    channel.send(embed)
   }
 }

--- a/src/commands/developers/blacklist.js
+++ b/src/commands/developers/blacklist.js
@@ -16,12 +16,12 @@ module.exports = class BlacklistCommand extends Command {
   }
 
   async run ({ channel, author, t }, user, reason) {
-    const embed = new SwitchbladeEmbed(author)
     const doc = await this.client.database.users.get(user.id)
     await BlacklistUtils.addUser(doc, reason, author)
-    embed
+    channel.send(
+      new SwitchbladeEmbed(author)
       .setTitle(t('commands:blacklist.successTitle'))
       .setDescription(`${user} - \`${reason}\``)
-    channel.send(embed)
+    )
   }
 }

--- a/src/commands/developers/reloadlocales.js
+++ b/src/commands/developers/reloadlocales.js
@@ -1,6 +1,6 @@
-const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
-const { Command, CommandRequirements } = CommandStructures
-module.exports = class reloadlocales extends Command {
+const { CommandStructures, SwitchbladeEmbed } = require('../../')
+const { Command, CommandRequirements, CommandError } = CommandStructures
+module.exports = class ReloadLocales extends Command {
   constructor (client) {
     super(client)
     this.name = 'reloadlocales'
@@ -11,18 +11,16 @@ module.exports = class reloadlocales extends Command {
   }
 
   async run ({ t, channel, author }) {
-    const embed = new SwitchbladeEmbed(author)
+    channel.startTyping()
     try {
-      this.client.downloadAndInitializeLocales('src/locales').then(() => {
-        embed
+      await this.client.downloadAndInitializeLocales('src/locales')
+      channel.send(
+        new SwitchbladeEmbed(author)
           .setTitle(t('commands:reloadlocales:reloaded'))
-        channel.send(embed)
-      })
+      )
     } catch (e) {
-      embed
-        .setColor(Constants.ERROR_COLOR)
-        .setTitle(t('errors:generic'))
-      channel.send(embed)
+      throw new CommandError(t('errors:generic'))
     }
+    channel.stopTyping()
   }
 }

--- a/src/commands/developers/unblacklist.js
+++ b/src/commands/developers/unblacklist.js
@@ -1,5 +1,5 @@
-const { CommandStructures, BlacklistUtils, SwitchbladeEmbed, Constants } = require('../../')
-const { Command, CommandRequirements, CommandParameters, UserParameter } = CommandStructures
+const { CommandStructures, BlacklistUtils, SwitchbladeEmbed } = require('../../')
+const { Command, CommandRequirements, CommandParameters, UserParameter, CommandError } = CommandStructures
 
 module.exports = class Unblacklist extends Command {
   constructor (client) {
@@ -15,16 +15,15 @@ module.exports = class Unblacklist extends Command {
   }
 
   async run ({ channel, author, t }, user) {
-    const embed = new SwitchbladeEmbed(author)
     const doc = await this.client.database.users.get(user.id)
     const ok = await BlacklistUtils.removeUser(doc)
     if (ok) {
-      embed.setDescription(`**${t('commands:unblacklist.success', { user: user })}**`)
+      channel.send(
+        new SwitchbladeEmbed(author)
+          .setDescription(`**${t('commands:unblacklist.success', { user: user })}**`)
+      )
     } else {
-      embed
-        .setColor(Constants.ERROR_COLOR)
-        .setTitle(t('commands:unblacklist.notBlacklisted'))
+      throw new CommandError(t('commands:unblacklist.notBlacklisted'))
     }
-    channel.send(embed)
   }
 }

--- a/src/commands/developers/whyblacklisted.js
+++ b/src/commands/developers/whyblacklisted.js
@@ -1,5 +1,5 @@
-const { CommandStructures, BlacklistUtils, SwitchbladeEmbed, Constants } = require('../../index')
-const { Command, CommandRequirements, CommandParameters, UserParameter } = CommandStructures
+const { CommandStructures, BlacklistUtils, SwitchbladeEmbed } = require('../../index')
+const { Command, CommandRequirements, CommandParameters, UserParameter, CommandError } = CommandStructures
 
 module.exports = class WhyBlacklisted extends Command {
   constructor (client) {
@@ -15,22 +15,19 @@ module.exports = class WhyBlacklisted extends Command {
   }
 
   async run ({ channel, author, t }, user) {
-    const embed = new SwitchbladeEmbed(author)
     const doc = await this.client.database.users.get(user.id)
     const info = await BlacklistUtils.getInfo(doc)
     if (info) {
-      const text = { user: user, blacklister: `<@${info.blacklisterId}>` }
-      embed.setDescription(
-        [
-          `**${t('commands:whyblacklisted.reasonTitle', text)}**`,
-          `\`${info.reason}\``
-        ].join('\n')
-      )
+      channel.send(new SwitchbladeEmbed(author)
+        .setDescription(
+          [
+            `**${t('commands:whyblacklisted.reasonTitle', { user, blacklister: `<@${info.blacklisterId}>` })}**`,
+            `\`${info.reason}\``
+          ].join('\n')
+        ))
     } else {
-      embed
-        .setColor(Constants.ERROR_COLOR)
-        .setTitle(t('commands:whyblacklisted.notBlacklisted'))
+      throw new CommandError(t('commands:whyblacklisted.notBlacklisted'))
     }
-    channel.send(embed)
+
   }
 }

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -21,7 +21,8 @@ module.exports = class Daily extends Command {
       embed.setColor(Constants.ERROR_COLOR)
       switch (e.message) {
         case 'ALREADY_CLAIMED':
-          embed.setTitle(t('commands:daily.alreadyClaimedTitle'))
+          embed
+            .setTitle(t('commands:daily.alreadyClaimedTitle'))
             .setDescription(t('commands:daily.alreadyClaimedDescription', { time: e.formattedCooldown }))
           break
         default:

--- a/src/commands/furry/e621.js
+++ b/src/commands/furry/e621.js
@@ -14,11 +14,12 @@ module.exports = class E621 extends Command {
 
   async run ({ t, author, channel }) {
     channel.startTyping()
-    const embed = new SwitchbladeEmbed(author)
-    const [ image ] = await booru.search('e621.net', ['rating:e'], { limit: 1, random: true }).then(booru.commonfy)
-    embed.setImage(image.common.file_url)
-      .setDescription(t('commands:e621.hereIsYour_yiff'))
-      .setColor(Constants.E621_COLOR)
-    channel.send(embed).then(() => channel.stopTyping())
+    const [ image ] = await booru.search('e621.net', ['rating:e'], { limit: 1, random: true })
+    channel.send(
+      new SwitchbladeEmbed(author)
+        .setImage(image.common.file_url)
+        .setDescription(t('commands:e621.hereIsYour_yiff'))
+        .setColor(Constants.E621_COLOR)
+    ).then(() => channel.stopTyping())
   }
 }

--- a/src/commands/games/beatsaver.js
+++ b/src/commands/games/beatsaver.js
@@ -1,4 +1,4 @@
-const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
+const { CommandStructures, SwitchbladeEmbed } = require('../../')
 const { Command, CommandParameters, StringParameter } = CommandStructures
 
 const snekfetch = require('snekfetch')
@@ -18,36 +18,27 @@ module.exports = class BeatSaver extends Command {
 
   async run ({ t, author, channel }, query) {
     channel.startTyping()
-    const embed = new SwitchbladeEmbed(author)
-    let url = await parseQuery(query)
+    const url = await parseQuery(query)
 
-    if (!url) {
-      embed
-        .setTitle(t('commands:beatsaver.notFound'))
-        .setColor(Constants.ERROR_COLOR)
-      channel.send(embed).then(channel.stopTyping())
-      return
-    }
+    if (!url) throw new CommandError(t('commands:beatsaver.notFound'))
 
     const { body } = await snekfetch.get(url)
     const $ = cheerio.load(body)
-    if (body) {
-      const title = $('body > div > div > h2').text()
-      const downloadUrl = $('body > div > div > div > div > a').attr('href')
-      const imageUrl = $('body > div > div > div > div > img').attr('src')
-      embed
+
+    if (!body) throw new CommandError(t('commands:beatsaver.notFound'), true)
+
+    const title = $('body > div > div > h2').text()
+    const downloadUrl = $('body > div > div > div > div > a').attr('href')
+    const imageUrl = $('body > div > div > div > div > img').attr('src')
+
+    channel.send(
+      new SwitchbladeEmbed(author)
         .setColor(0x3C347B)
         .setAuthor('Beat Saver', 'https://i.imgur.com/yK8SmyX.png')
         .setTitle(title)
         .setThumbnail(imageUrl)
         .setDescription(`**[${t('commands:beatsaver.download')}](${downloadUrl})** - [${t('commands:beatsaver.details')}](${url})`)
-    } else {
-      embed
-        .setTitle(t('commands:beatsaver.notFound'))
-        .setColor(Constants.ERROR_COLOR)
-    }
-
-    channel.send(embed).then(channel.stopTyping())
+    ).then(channel.stopTyping())
   }
 }
 

--- a/src/commands/games/betflip.js
+++ b/src/commands/games/betflip.js
@@ -1,5 +1,5 @@
-const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
-const { Command, CommandParameters, NumberParameter, StringParameter } = CommandStructures
+const { CommandStructures, SwitchbladeEmbed } = require('../../')
+const { Command, CommandParameters, NumberParameter, StringParameter, CommandError } = CommandStructures
 
 module.exports = class Betflip extends Command {
   constructor (client) {
@@ -13,24 +13,23 @@ module.exports = class Betflip extends Command {
   }
 
   async run ({ channel, author, t }, bet, side) {
-    const embed = new SwitchbladeEmbed(author)
     channel.startTyping()
 
     try {
       const { won, chosenSide } = await this.modules.economy.betflip(author.id, bet, side)
-      embed.setImage(`https://raw.githubusercontent.com/bolsomito/koi/master/bin/assets/${chosenSide}.png`)
-        .setDescription(t(`commands:betflip.${won ? 'victory' : 'loss'}`, { chosenSide, count: bet }))
+      channel.send(
+        new SwitchbladeEmbed(author)
+          .setDescription(t(`commands:betflip.${won ? 'victory' : 'loss'}`, { chosenSide, count: bet }))
+      )
     } catch (e) {
-      embed.setColor(Constants.ERROR_COLOR)
       switch (e.message) {
         case 'NOT_ENOUGH_MONEY':
-          embed.setTitle(t('errors:notEnoughMoney'))
-          break
+          throw new CommandError(t('errors:notEnoughMoney'))
         default:
-          embed.setTitle(t('errors:generic'))
+          throw new CommandError(t('errors:notEnoughMoney'))
       }
     }
 
-    channel.send(embed).then(() => channel.stopTyping())
+    channel.stopTyping()
   }
 }

--- a/src/commands/games/betflip.js
+++ b/src/commands/games/betflip.js
@@ -26,7 +26,7 @@ module.exports = class Betflip extends Command {
         case 'NOT_ENOUGH_MONEY':
           throw new CommandError(t('errors:notEnoughMoney'))
         default:
-          throw new CommandError(t('errors:notEnoughMoney'))
+          throw new CommandError(t('errors:generic'))
       }
     }
 

--- a/src/commands/games/coinflip.js
+++ b/src/commands/games/coinflip.js
@@ -11,10 +11,9 @@ module.exports = class Coinflip extends Command {
   run ({ channel, author, t }) {
     const sides = ['heads', 'tails']
     const chosenSide = sides[Math.floor(Math.random() * sides.length)]
-    const embed = new SwitchbladeEmbed(author)
-    channel.startTyping()
-    embed.setDescription(t('commands:coinflip.landed', { chosenSide }))
-      .setImage(`https://raw.githubusercontent.com/bolsomito/koi/master/bin/assets/${chosenSide}.png`)
-    channel.send(embed).then(() => channel.stopTyping())
+    channel.send(
+      new SwitchbladeEmbed(author)
+        .setDescription(t('commands:coinflip.landed', { chosenSide }))
+    )
   }
 }

--- a/src/commands/games/steamladder.js
+++ b/src/commands/games/steamladder.js
@@ -11,9 +11,6 @@ const embedColor = 0x292B2D
 const ladders = ['xp', 'games', 'badges', 'playtime', 'age']
 const regions = ['europe', 'north_america', 'south_america', 'asia', 'africa', 'oceania', 'antarctica']
 
-// TODO: Finish the ladder command
-// TODO: Add profile subcommand
-
 module.exports = class SteamLadder extends Command {
   constructor (client) {
     super(client)


### PR DESCRIPTION
### What does this PR change?
- Make every command that throws errors use `CommandError` (except some TODOs)
- Fix startTypings/stopTypings (Closes #566)
- Use the `nekos.life` npm module for nekos.life commands instead of requesting stuff by hand
- General fixes (uncapitalized class names and such)