### PR TITLE
Tic Tac Toe game

### DIFF
--- a/src/commands/games/tictactoe.js
+++ b/src/commands/games/tictactoe.js
@@ -1,0 +1,198 @@
+const { CommandStructures, SwitchbladeEmbed, Constants } = require('../../')
+const { Command, CommandParameters, MemberParameter, CommandRequirements, BooleanFlagParameter } = CommandStructures
+
+const COLLECTOR_TIMEOUT = 30
+const CONFIRMATION_EMOJI = '✅'
+const BOARDS = {
+  default: {
+    players: [':regional_indicator_x:', ':regional_indicator_o:'],
+    emptySpaces: [
+      [':one:', ':two:', ':three:'],
+      [':four:', ':five:', ':six:'],
+      [':seven:', ':eight:', ':nine:']
+    ],
+    reactionButtons: ['1⃣', '2⃣', '3⃣', '4⃣', '5⃣', '6⃣', '7⃣', '8⃣', '9⃣'],
+    horizontalSeparator: '\n'
+  },
+  text: {
+    players: [' X ', ' O '],
+    emptySpaces: [
+      [' 1 ', ' 2 ', ' 3 '],
+      [' 4 ', ' 5 ', ' 6 '],
+      [' 7 ', ' 8 ', ' 9 ']
+    ],
+    reactionButtons: ['1⃣', '2⃣', '3⃣', '4⃣', '5⃣', '6⃣', '7⃣', '8⃣', '9⃣'],
+    verticalSeparator: '|',
+    horizontalSeparator: '\n───┼───┼───\n',
+    boardPrefix: '```',
+    boardSuffix: '```'
+  }
+}
+
+const winConditions = [
+  [[0, 0], [1, 1], [2, 2]],
+  [[2, 0], [1, 1], [0, 2]],
+  [[0, 2], [1, 2], [2, 2]],
+  [[0, 0], [1, 0], [2, 0]],
+  [[2, 0], [2, 1], [2, 2]],
+  [[0, 0], [0, 1], [0, 2]],
+  [[0, 1], [1, 1], [2, 1]],
+  [[1, 0], [1, 1], [1, 2]]
+]
+const gridToLinear = [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]]
+
+module.exports = class TicTacToe extends Command {
+  constructor (client) {
+    super(client)
+    this.name = 'tictactoe'
+    this.aliases = ['ttt']
+
+    this.category = 'games'
+
+    this.requirements = new CommandRequirements(this, { guildOnly: true, botPermissions: ['MANAGE_MESSAGES'], permissions: ['ADD_REACTIONS'] })
+
+    this.parameters = new CommandParameters(this,
+      new MemberParameter({ missingError: 'commands:tictactoe.missingUser', acceptSelf: true }),
+      [
+        new BooleanFlagParameter({ name: 'text' })
+      ]
+    )
+  }
+
+  async run ({ channel, member, author, t, flags }, opponent) {
+    const selectedBoard = flags['text'] ? BOARDS['text'] : BOARDS['default']
+    const gameMessage = await channel.send(
+      opponent,
+      new SwitchbladeEmbed(author)
+        .setAuthor(
+          t('commands:tictactoe.hasChallenged', { player: member.displayName }),
+          author.displayAvatarURL
+        )
+        .setDescription([
+          t('commands:tictactoe.clickTheReaction', { CONFIRMATION_EMOJI }),
+          `**(${t('commands:tictactoe.thisTimeoutsIn', { COLLECTOR_TIMEOUT })})**`
+        ].join('\n'))
+    )
+    await gameMessage.react(CONFIRMATION_EMOJI)
+    const result = await gameMessage.awaitReactions((r, u) => r.emoji.name === CONFIRMATION_EMOJI && u.id === opponent.id, { time: COLLECTOR_TIMEOUT * 1000, maxEmojis: 1 })
+
+    if (!result.size) {
+      gameMessage.edit(
+        new SwitchbladeEmbed(author)
+          .setColor(Constants.ERROR_COLOR)
+          .setTitle(t('commands:tictactoe.timeout'))
+      )
+      gameMessage.clearReactions()
+      return
+    }
+
+    let gameState = {
+      players: [member, opponent],
+      currentPlayer: 0,
+      board: [
+        [null, null, null],
+        [null, null, null],
+        [null, null, null]
+      ]
+    }
+
+    await gameMessage.clearReactions()
+    let loadComplete = false
+    const collector = gameMessage.createReactionCollector(() => true)
+    collector.on('collect', async (reaction) => {
+      const selectedCoordinate = gridToLinear[selectedBoard.reactionButtons.findIndex(c => c === reaction.emoji.name)]
+      if (loadComplete && selectedBoard.reactionButtons.includes(reaction.emoji.name) && reaction.users.some(u => u.id === gameState.players[gameState.currentPlayer].id) && this.isSpaceEmpty(gameState, selectedCoordinate)) {
+        gameState.board[selectedCoordinate[0]][selectedCoordinate[1]] = gameState.currentPlayer
+        gameState.currentPlayer = gameState.currentPlayer === 1 ? 0 : 1
+        reaction.users.forEach(u => { reaction.remove(u) })
+        if (this.getWinner(gameState) !== undefined) {
+          gameMessage.edit(
+            new SwitchbladeEmbed()
+              .setTitle(t('commands:tictactoe.title'))
+              .setDescription(
+                [
+                  this.renderBoard(gameState, selectedBoard),
+                  `:crown: **${t('commands:tictactoe.wins', { player: gameState.players[this.getWinner(gameState)] })}**`
+                ].join('\n\n')
+              )
+          )
+          gameMessage.clearReactions()
+          collector.stop()
+        } else if (this.getEmptySpaceCount(gameState) === 0) {
+          gameMessage.edit(
+            new SwitchbladeEmbed()
+              .setTitle(t('commands:tictactoe.title'))
+              .setDescription(
+                [
+                  this.renderBoard(gameState, selectedBoard),
+                  `:anger: **${t('commands:tictactoe.itsATie')}**`
+                ].join('\n\n')
+              )
+          )
+          gameMessage.clearReactions()
+          collector.stop()
+        } else {
+          this.updateEmbed(gameState, selectedBoard, gameMessage, t, author)
+        }
+      } else {
+        reaction.users.forEach(u => {
+          if (u.id !== this.client.user.id) reaction.remove(u)
+        })
+      }
+    })
+    await gameMessage.edit(
+      new SwitchbladeEmbed(author)
+        .setTitle(t('commands:tictactoe.title'))
+        .setDescription(t('commands:tictactoe.pleaseWait'))
+    )
+    const reactionEmoji = selectedBoard.reactionButtons || Array.prototype.concat.apply([], selectedBoard.emptySpaces)
+    for (const emoji of reactionEmoji) {
+      await gameMessage.react(emoji)
+    }
+    await this.updateEmbed(gameState, selectedBoard, gameMessage, t, author)
+    loadComplete = true
+  }
+
+  renderBoard (gameState, boardInfo) {
+    return `${boardInfo.boardPrefix || ''}${
+      gameState.board.map((line, lineNumber) => {
+        return line.map((space, columnNumber) => {
+          return space !== null ? boardInfo.players[space] : boardInfo.emptySpaces[lineNumber][columnNumber]
+        }).join(`${boardInfo.verticalSeparator || ''}`)
+      }).join(boardInfo.horizontalSeparator || '')
+    }${boardInfo.boardSuffix || ''}`
+  }
+
+  updateEmbed (gameState, boardInfo, gameMessage, t, author) {
+    return gameMessage.edit(
+      t('commands:tictactoe.itsYourTurn', { player: gameState.players[gameState.currentPlayer] }),
+      new SwitchbladeEmbed(author)
+        .setTitle(t('commands:tictactoe.title'))
+        .setDescription(this.renderBoard(gameState, boardInfo))
+        .addField(t('commands:tictactoe.currentPlayer'), `${boardInfo.players[gameState.currentPlayer]} ${gameState.players[gameState.currentPlayer]}`)
+    )
+  }
+
+  isSpaceEmpty (gameState, spaceCoordinate) {
+    return gameState.board[spaceCoordinate[0]][spaceCoordinate[1]] === null
+  }
+
+  getWinner (gameState) {
+    for (const conditionCoordinates of winConditions) {
+      const spaceValues = this.getSpaceValues(gameState, conditionCoordinates)
+      if (spaceValues.every((value, index, array) => value === array[0]) && spaceValues[0] !== null) {
+        return spaceValues[0]
+      }
+    }
+  }
+
+  getSpaceValues (gameState, coordinateArray) {
+    return coordinateArray.map(coordinate => {
+      return gameState.board[coordinate[0]][coordinate[1]]
+    })
+  }
+
+  getEmptySpaceCount (gameState) {
+    return Array.prototype.concat.apply([], gameState.board).filter(s => s === null).length
+  }
+}

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -729,5 +729,20 @@
     "commandDescription": "Generates a Presidential Alert notifications",
     "commandUsage": "<text>",
     "missingText": "You need to give me some text for the alert"
+  },
+  "tictactoe": {
+    "commandDescription": "Challenge someone to a game of tic tac toe",
+    "commandUsage": "<user to challenge>",
+    "missingUser": "You need to give me someone to challenge",
+    "title": "Tic Tac Toe",
+    "pleaseWait": "Please wait, loading board...",
+    "currentPlayer": "Current player",
+    "itsYourTurn": "It's your turn, {{player}}",
+    "itsATie": "It's a tie!",
+    "wins": "{{player}} wins!",
+    "timeout": "This Tic Tac Toe invite has timed out.",
+    "hasChallenged": "{{player}} has challenged you to a game of Tic Tac Toe",
+    "clickTheReaction": "Click the {{CONFIRMATION_EMOJI}} reaction button below to accept.",
+    "thisTimeoutsIn": "This timeouts in {{COLLECTOR_TIMEOUT}} seconds"
   }
 }

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -726,12 +726,12 @@
     "clickHere": "**[Click here to join my support server](https://invite.switchblade.xyz)**"
   },
   "presidentialalert": {
-    "commandDescription": "Generates a Presidential Alert notifications",
+    "commandDescription": "Generates a Presidential Alert notification",
     "commandUsage": "<text>",
     "missingText": "You need to give me some text for the alert"
   },
   "tictactoe": {
-    "commandDescription": "Challenge someone to a game of tic tac toe",
+    "commandDescription": "Challenge someone to a game of Tic Tac Toe",
     "commandUsage": "<user to challenge>",
     "missingUser": "You need to give me someone to challenge",
     "title": "Tic Tac Toe",

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -743,6 +743,6 @@
     "timeout": "This Tic Tac Toe invite has timed out.",
     "hasChallenged": "{{player}} has challenged you to a game of Tic Tac Toe",
     "clickTheReaction": "Click the {{CONFIRMATION_EMOJI}} reaction button below to accept.",
-    "thisTimeoutsIn": "This timeouts in {{COLLECTOR_TIMEOUT}} seconds"
+    "thisTimeoutsIn": "You have {{COLLECTOR_TIMEOUT}} seconds to accept it"
   }
 }

--- a/src/structures/command/parameters/types/MemberParameter.js
+++ b/src/structures/command/parameters/types/MemberParameter.js
@@ -6,10 +6,11 @@ const MENTION_REGEX = /^(?:<@!?)?([0-9]{16,18})(?:>)?$/
 // TODO: Make this extend UserParameter
 module.exports = class MemberParameter extends Parameter {
   constructor (options = {}) {
-    options = Object.assign({ acceptBot: false, acceptUser: true }, options)
+    options = Object.assign({ acceptBot: false, acceptUser: true, acceptSelf: false }, options)
     super(options)
     this.acceptBot = !!options.acceptBot
     this.acceptUser = !!options.acceptUser
+    this.acceptSelf = !!options.acceptSelf
   }
 
   parse (arg, context) {
@@ -20,9 +21,10 @@ module.exports = class MemberParameter extends Parameter {
     return this.member(context, userId)
   }
 
-  member ({ t, guild }, id) {
+  member ({ t, guild, author }, id) {
     const member = guild.members.get(id)
     if (!member) throw new CommandError(t('errors:invalidUser'))
+    if (!this.acceptSelf && id === author.id) throw new CommandError(t('errors:sameUser'))
     if (!this.acceptBot && member.user.bot) throw new CommandError(t('errors:invalidUserBot'))
     if (!this.acceptUser && !member.user.bot) throw new CommandError(t('errors:invalidUserNotBot'))
     return member


### PR DESCRIPTION
**I SPENT 8 HOURS WRITING THIS NON-STOP WHILE LIVESTREAMING**

- Adds the Tic Tac Toe command
  - You can add the `--text` flag to run the game inside a codeblock instead of using emoji
  - The command supports "custom board designs", but they are currently hardcoded. In the future, we could allow users to add their own board designs.
- Adds the `acceptSelf` flag to `MemberParameter`

### Screenshots
![image](https://user-images.githubusercontent.com/25179120/51648836-50416180-1f69-11e9-8538-7817ca65c947.png)
![image](https://user-images.githubusercontent.com/25179120/51648840-53d4e880-1f69-11e9-9949-b6dbb38707d9.png)
