### PR TITLE
Experimental optional parameter improvement

### DIFF
--- a/src/commands/social/ship.js
+++ b/src/commands/social/ship.js
@@ -10,7 +10,7 @@ module.exports = class Ship extends Command {
 
     this.parameters = new CommandParameters(this,
       new UserParameter({ acceptSelf: true, required: false }),
-      new UserParameter({ acceptSelf: true, missingError: 'commands:ship.noUser' }),
+      new UserParameter({ acceptSelf: true, missingError: 'commands:ship.noUser' })
     )
   }
 

--- a/src/commands/social/ship.js
+++ b/src/commands/social/ship.js
@@ -9,16 +9,12 @@ module.exports = class Ship extends Command {
     this.category = 'social'
 
     this.parameters = new CommandParameters(this,
-      new UserParameter({ required: true, acceptSelf: true, missingError: 'commands:ship.noUser' }),
-      new UserParameter({ required: false, acceptSelf: true })
+      new UserParameter({ acceptSelf: true, required: false }),
+      new UserParameter({ acceptSelf: true, missingError: 'commands:ship.noUser' }),
     )
   }
 
-  async run ({ t, author, channel, guild }, first, second) {
-    if (!second) {
-      second = first
-      first = author
-    }
+  async run ({ t, author, channel, guild }, first = author, second) {
     channel.startTyping()
 
     const { username: firstName } = first

--- a/src/commands/utility/currency.js
+++ b/src/commands/utility/currency.js
@@ -1,5 +1,5 @@
 const { CommandStructures, SwitchbladeEmbed } = require('../../')
-const { Command, CommandError } = CommandStructures
+const { Command, CommandError, CommandParameters, NumberParameter, StringParameter } = CommandStructures
 const snekfetch = require('snekfetch')
 
 module.exports = class Currency extends Command {
@@ -9,9 +9,15 @@ module.exports = class Currency extends Command {
     this.aliases = ['currencyconverter', 'converter']
     this.category = 'utility'
     this.envVars = ['KSOFT_KEY']
+
+    this.parameters = new CommandParameters(this,
+      new StringParameter({ required: false }),
+      new NumberParameter({ required: false, min: 1 }),
+      new StringParameter({ missingError: 'commands:currency.noCurrency' })
+    )
   }
 
-  async run ({ t, author, channel }, to, from = 'USD', value = 1) {
+  async run ({ t, author, channel }, from = 'USD', value = 1, to) {
     const embed = new SwitchbladeEmbed(author)
     try {
       const { body } = await snekfetch.get('https://api.ksoft.si/kumo/currency').query({ to, from, value }).set({

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -874,7 +874,7 @@
   },
   "currency": {
     "commandDescription": "Shows the current rate of a currency or a pair.",
-    "commandUsage": "<to> [from] [value]",
+    "commandUsage": "[from] [value] <to>",
     "noCurrency": "You have to give me a valid currency or a pair."
   },
   "joinlock": {

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -999,7 +999,7 @@
   },
   "ship": {
     "commandDescription": "Ship yourself or someone with somebody else.",
-    "commandUsage": "<first user> [second user]",
+    "commandUsage": "[first user] <second user>",
     "noUser": "Please insert someone to ship",
     "messages": {
       "high": {

--- a/src/structures/command/parameters/CommandParameters.js
+++ b/src/structures/command/parameters/CommandParameters.js
@@ -63,14 +63,26 @@ module.exports = class CommandParameters {
    */
   handleArguments (context, args) {
     const parsedArgs = []
+
+    let argIndex = 0
     for (let i = 0; i < this.parameters.length; i++) {
       const param = this.parameters[i]
 
-      let arg = args[i]
-      if (param.full) arg = args.slice(i).join(param.fullJoin || ' ')
+      let arg = args[argIndex]
+      if (
+        this.parameters.length > args.length &&
+        !param.required && argIndex === args.length - 1 &&
+        this.parameters.some((p, pi) => pi > i && p.required)
+      ) {
+        parsedArgs.push(undefined)
+        continue
+      }
+
+      if (param.full) arg = args.slice(argIndex).join(param.fullJoin || ' ')
 
       const parsedArg = this.parseParameter(context, param, arg, funcOrString(param.missingError, context.t, context))
       parsedArgs.push(parsedArg)
+      argIndex++
     }
     return parsedArgs
   }


### PR DESCRIPTION
- Closes #593 
  - New syntax: `s!currency [from] [value] <to>`
  - ![image](https://user-images.githubusercontent.com/10660904/52915887-0d4c8280-32b8-11e9-96bf-181864c6f37d.png)
