### PR TITLE
🐛 Fixed a bug where emojis didn't work on EmojiParameter commands

### DIFF
--- a/src/commands/utility/restrictemoji/add.js
+++ b/src/commands/utility/restrictemoji/add.js
@@ -7,7 +7,7 @@ module.exports = class RestrictEmojiAdd extends Command {
     this.name = 'add'
 
     this.parameters = new CommandParameters(this,
-      new EmojiParameter({ full: false, required: true, sameGuildOnly: true }),
+      new EmojiParameter({ full: false, required: true }),
       new RoleParameter({ full: true, required: true })
     )
   }

--- a/src/commands/utility/restrictemoji/remove.js
+++ b/src/commands/utility/restrictemoji/remove.js
@@ -7,7 +7,7 @@ module.exports = class RestrictEmojiRemove extends Command {
     this.name = 'remove'
 
     this.parameters = new CommandParameters(this,
-      new EmojiParameter({ full: false, required: true, sameGuildOnly: true }),
+      new EmojiParameter({ full: false, required: true }),
       new RoleParameter({ full: true, required: true })
     )
   }

--- a/src/commands/utility/restrictemoji/reset.js
+++ b/src/commands/utility/restrictemoji/reset.js
@@ -7,7 +7,7 @@ module.exports = class RestrictEmojiReset extends Command {
     this.name = 'reset'
 
     this.parameters = new CommandParameters(this,
-      new EmojiParameter({ full: false, required: true, sameGuildOnly: true })
+      new EmojiParameter({ full: false, required: true })
     )
   }
 

--- a/src/structures/command/parameters/types/EmojiParameter.js
+++ b/src/structures/command/parameters/types/EmojiParameter.js
@@ -6,10 +6,9 @@ const ANIMATED_REGEX = /^(?:<a:)(.*?)(?::)([0-9]{18})(?:>)$/
 
 module.exports = class EmojiParameter extends Parameter {
   constructor (options = {}) {
-    options = Object.assign({ sameGuildOnly: false, acceptEmojiNames: true }, options)
+    options = Object.assign({ sameGuildOnly: false }, options)
     super(options)
     this.sameGuildOnly = !!options.sameGuildOnly
-    this.acceptEmojiNames = !!options.acceptEmojiNames
   }
 
   parse (arg, { t, guild }) {
@@ -22,6 +21,7 @@ module.exports = class EmojiParameter extends Parameter {
     let emojiIsAnimated = ''
 
     if (regexResult) {
+      if (this.sameGuildOnly && !guild.emojis.get(regexResult[2])) throw new CommandError(t('errors:emojiNotFromSameGuild'))
       emojiName = regexResult[1]
       emojiId = regexResult[2]
       emojiIsAnimated = Boolean(animatedRegexResult)

--- a/src/structures/command/parameters/types/EmojiParameter.js
+++ b/src/structures/command/parameters/types/EmojiParameter.js
@@ -21,14 +21,13 @@ module.exports = class EmojiParameter extends Parameter {
     let emojiId = ''
     let emojiIsAnimated = ''
 
-    if (!this.acceptEmojiNames) {
-      if (!regexResult) throw new CommandError(t('errors:invalidEmoji'))
+    if (regexResult) {
       emojiName = regexResult[1]
       emojiId = regexResult[2]
       emojiIsAnimated = Boolean(animatedRegexResult)
     }
 
-    if (this.acceptEmojiNames) {
+    if (!regexResult) {
       const emoji = guild.emojis.find('name', arg)
       if (!emoji) throw new CommandError(t('errors:invalidEmoji'))
       if (this.sameGuildOnly && !emoji) throw new CommandError(t('errors:emojiNotFromSameGuild'))


### PR DESCRIPTION
Fixed the bug when, for example, <:pillthonk:477280359801815060>, didn't work in commands using EmojiParameter