### PR TITLE
Crowdin docker fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,4 @@ workflows:
       - crowdin-upload:
           filters:
             branches:
-              only: /dev/
+              only: /dev|crowdin-docker-fix/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   crowdin-upload:
     docker:
-      - image: alconost/crowdin
+      - image: dougley/crowdin
     steps:
       - checkout
       - run: crowdin upload sources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,4 @@ workflows:
       - crowdin-upload:
           filters:
             branches:
-              only: /dev|crowdin-docker-fix/
+              only: /dev/


### PR DESCRIPTION
The **Crowdin CLI** docker image we had been used has been deleted from Docker Hub. This PR fixes failed Crowdin uploads by replacing it with **dougley/crowdin**.