### PR TITLE
Fix #842 and redesign npm embed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2921,8 +2921,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2965,8 +2964,7 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2977,8 +2975,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3095,8 +3092,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3108,7 +3104,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3138,7 +3133,6 @@
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3157,7 +3151,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3251,7 +3244,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3337,8 +3329,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3374,7 +3365,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3394,7 +3384,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3438,14 +3427,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/commands/utility/npm.js
+++ b/src/commands/utility/npm.js
@@ -27,15 +27,28 @@ module.exports = class Npm extends SearchCommand {
   }
 
   async handleResult ({ t, channel, author, language }, pkg) {
+    console.log(pkg)
     const embed = new SwitchbladeEmbed(author)
     moment.locale(language)
     channel.startTyping()
-    embed.setColor(Constants.NPM_COLOR)
-      .setAuthor(`${pkg.name} - v${pkg.version}`, this.embedLogoURL, pkg.links.npm)
-      .setDescription(`${pkg.description || t('commands:npm.noDescription')}\n${pkg.links.npm}`)
-      .addField(t('commands:npm.lastPublish'), moment(pkg.date).format('LLL'), true)
-      .addField(t('commands:npm.install'), `\`npm install --save ${pkg.name}\``, true)
-    if (pkg.keywords.length > 0) embed.addField(t('commands:npm:keywords'), pkg.keywords.map(k => `\`${k}\``).join(', '), true)
+    embed
+      .setColor(Constants.NPM_COLOR)
+      .setAuthor('npm', this.embedLogoURL, 'https://www.npmjs.com/')
+      .setDescriptionFromBlockArray([
+        [
+          `[${pkg.name}](${pkg.links.npm})`,
+          pkg.description ? pkg.description : null
+        ],
+        [
+          pkg.keywords && pkg.keywords.length > 0 ? pkg.keywords.map(k => `\`${k}\``).join(', ') : null
+        ],
+        [
+          t('commands:npm.published', { publisher: pkg.publisher.username, version: pkg.version, timeAgo: moment(pkg.date).fromNow() })
+        ],
+        [
+          `\`\`\`npm i ${pkg.name}\`\`\``
+        ]
+      ])
     channel.send(embed).then(() => channel.stopTyping())
   }
 }

--- a/src/commands/utility/npm.js
+++ b/src/commands/utility/npm.js
@@ -27,7 +27,6 @@ module.exports = class Npm extends SearchCommand {
   }
 
   async handleResult ({ t, channel, author, language }, pkg) {
-    console.log(pkg)
     const embed = new SwitchbladeEmbed(author)
     moment.locale(language)
     channel.startTyping()

--- a/src/locales/en-US/commands.json
+++ b/src/locales/en-US/commands.json
@@ -237,7 +237,8 @@
     "noNameProvided": "You have to give me a package name!",
     "lastPublish": "Last publish",
     "install": "Install",
-    "keywords": "Keywords"
+    "keywords": "Keywords",
+    "published": "**{{publisher}}** published `{{version}}` {{timeAgo}}"
   },
   "poll": {
     "commandDescription": "Creates a poll.",

--- a/src/structures/SwitchbladeEmbed.js
+++ b/src/structures/SwitchbladeEmbed.js
@@ -12,4 +12,24 @@ module.exports = class SwitchbladeEmbed extends RichEmbed {
     this.setColor(process.env.EMBED_COLOR).setTimestamp()
     if (user) this.setFooter(user.tag)
   }
+
+  /**
+   * Sets the description of this embed based on an array of arrays of strings
+   * @param {Array<Array>} Array containing arrays (blocks) of and strings
+   * @returns {SwitchbladeEmbed}
+   */
+  setDescriptionFromBlockArray (blocks) {
+    blocks = blocks
+      .map(
+        blockLines => blockLines.filter(
+          line => line != null
+        )
+      ).filter(
+        blockLines => blockLines.length > 0 && blockLines != null
+      ).map(
+        blockLines => blockLines.join('\n')
+      ).join('\n\n')
+    this.description = blocks
+    return this
+  }
 }


### PR DESCRIPTION
## Changes
- Fixes #842 
- Adds `setDescriptionFromBlockArray` method to `SwitchbladeEmbed`. This method will be used later on to solve formatting issues in the chorus command.
- Redesigns the npm embed cause I thought it looked terrible.

## Screenshots
![image](https://user-images.githubusercontent.com/25179120/58384573-92cb8700-7fb9-11e9-8658-fcad6483fd37.png)

![image](https://user-images.githubusercontent.com/25179120/58384655-a0cdd780-7fba-11e9-9244-8dcbb5fc7aae.png)
