### PR TITLE
Fix TypeError

### DIFF
--- a/src/apis/DarkSky.js
+++ b/src/apis/DarkSky.js
@@ -8,7 +8,7 @@ module.exports = class DarkSkyAPI extends APIWrapper {
   constructor () {
     super({
       name: 'darksky',
-      envVars: 'DARKSKY_KEY'
+      envVars: [ 'DARKSKY_KEY' ]
     })
   }
 


### PR DESCRIPTION
`TypeError: api.envVars.every is not a function`

`DarkSky.js` was missing brackets on the `envVars` option, causing the API loader to throw an error when loading it. This PR fixes that.