### PR TITLE
Reminders

### DIFF
--- a/src/commands/anime/neko.js
+++ b/src/commands/anime/neko.js
@@ -1,5 +1,5 @@
 const { Command, SwitchbladeEmbed } = require('../../')
-const fetch = require('node-fetch')
+const snekfetch = require('snekfetch')
 const nekoAPI = 'https://nekos.life/api/v2/img/'
 
 module.exports = class Neko extends Command {
@@ -18,7 +18,7 @@ module.exports = class Neko extends Command {
     // Send a lewd neko if the channel is NSFW
     const endpoint = channel.nsfw ? 'lewd' : 'neko'
 
-    const { url } = await fetch(nekoAPI + endpoint).then(res => res.json())
+    const { body: { url } } = await snekfetch.get(nekoAPI + endpoint)
 
     embed.setImage(url)
       .setDescription(t('commands:neko.hereIsYour', { context: endpoint }))

--- a/src/commands/utility/reminder.js
+++ b/src/commands/utility/reminder.js
@@ -1,0 +1,20 @@
+const { Command, SwitchbladeEmbed } = require('../../')
+
+module.exports = class Reminder extends Command {
+  constructor (client) {
+    super(client, {
+      name: 'reminder',
+      aliases: ['remindme'],
+      category: 'utility',
+      parameters: [{
+        type: 'string',
+        full: true,
+        missingError: 'commands:reminder.missingDate'
+      }]
+    })
+  }
+
+  async run ({ t, author, channel, message, language }, dateString) {
+    // Stuff
+  }
+}

--- a/src/database/mongo/MongoDB.js
+++ b/src/database/mongo/MongoDB.js
@@ -1,5 +1,5 @@
 const DBWrapper = require('../DBWrapper.js')
-const { GuildRepository, UserRepository } = require('./repositories')
+const { GuildRepository, UserRepository, ReminderRepository } = require('./repositories')
 
 const mongoose = require('mongoose')
 
@@ -13,6 +13,7 @@ module.exports = class MongoDB extends DBWrapper {
     return mongoose.connect(process.env.MONGODB_URI, this.options).then((m) => {
       this.guilds = new GuildRepository(m)
       this.users = new UserRepository(m)
+      this.reminders = new ReminderRepository(m)
     })
   }
 }

--- a/src/database/mongo/repositories/ReminderRepository.js
+++ b/src/database/mongo/repositories/ReminderRepository.js
@@ -1,0 +1,14 @@
+const MongoRepository = require('../MongoRepository.js')
+const ReminderSchema = require('../schemas/ReminderSchema.js')
+
+module.exports = class ReminderRepository extends MongoRepository {
+  constructor (mongoose) {
+    super(mongoose, mongoose.model('Reminder', ReminderSchema))
+  }
+
+  parse (entity) {
+    return {
+      ...(super.parse(entity) || {})
+    }
+  }
+}

--- a/src/database/mongo/repositories/index.js
+++ b/src/database/mongo/repositories/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   GuildRepository: require('./GuildRepository.js'),
-  UserRepository: require('./UserRepository.js')
+  UserRepository: require('./UserRepository.js'),
+  ReminderRepository: require('./ReminderRepository.js')
 }

--- a/src/database/mongo/schemas/ReminderSchema.js
+++ b/src/database/mongo/schemas/ReminderSchema.js
@@ -1,0 +1,10 @@
+const { Schema } = require('mongoose')
+
+module.exports = new Schema({
+  _id: String,
+  userId: String,
+  messageId: String,
+  channelId: String,
+  text: String,
+  timestamp: String
+})


### PR DESCRIPTION
Closes #86

- [x] **Database schema**
  - Reminder id
    - Maybe 5-letter codes, just like URL shorteners?
  - User id
  - Message id
  - Channel id
  - Text (optional)
  - Timestamp
- [ ] **`s!remindme` command**
  - Should parse human-readable date/time strings, just like the reddit RemindMe bot. [This can probably be done with Datejs](https://github.com/datejs/Datejs), but I was thinking of writing our own library based on it. **See [bladiem](https://github.com/SwitchbladeBot/bladiem).**
  - Should allow users to set a text for the reminder with `"double-quoted strings"` or a `--text` flag
  - `s!reminder cancel <id>` should be a thing
- [ ] **Trigger the reminders at the right time**
  - This would remove the reminder from the database, obviously.