### PR TITLE
Command loading error message fix

### DIFF
--- a/src/commands/games/leagueoflegends/champion.js
+++ b/src/commands/games/leagueoflegends/champion.js
@@ -8,7 +8,6 @@ module.exports = class LeagueOfLegendsChampion extends Command {
       name: 'champion',
       aliases: ['champ', 'c'],
       parentCommand: 'leagueoflegends',
-      requirements: { apis: ['lol'] },
       parameters: [{
         type: 'string', full: true, missingError: 'commands:leagueoflegends.subcommands.champion.noChampion'
       }]

--- a/src/commands/games/leagueoflegends/rotation.js
+++ b/src/commands/games/leagueoflegends/rotation.js
@@ -6,7 +6,6 @@ module.exports = class LeagueOfLegendsRotation extends Command {
       name: 'rotation',
       aliases: ['r'],
       parentCommand: 'leagueoflegends',
-      requirements: { apis: ['lol'] },
       parameters: [[{
         type: 'booleanFlag', name: 'newplayers', aliases: ['np']
       }]]

--- a/src/loaders/CommandLoader.js
+++ b/src/loaders/CommandLoader.js
@@ -41,22 +41,16 @@ module.exports = class CommandLoader extends Loader {
    * @param {Command} command - Command to be added
    */
   addCommand (command) {
-    const check = this.checkCommand(command)
-    if (!check) return check
-
     if (typeof command.parentCommand === 'string' || Array.isArray(command.parentCommand)) {
       this.posLoadCommands.push(command)
     } else {
+      const check = this.checkCommand(command)
+      if (!check) return check
       this.commands.push(command)
     }
-
-    return check
   }
 
   addSubcommand (subCommand) {
-    const check = this.checkCommand(subCommand)
-    if (!check) return check
-
     let parentCommand
     if (typeof subCommand.parentCommand === 'string') {
       parentCommand = this.commands.find(c => c.name === subCommand.parentCommand)
@@ -78,6 +72,7 @@ module.exports = class CommandLoader extends Loader {
       return false
     }
 
+    const check = this.checkCommand(subCommand)
     return check
   }
 

--- a/src/loaders/CommandLoader.js
+++ b/src/loaders/CommandLoader.js
@@ -48,6 +48,8 @@ module.exports = class CommandLoader extends Loader {
       if (!check) return check
       this.commands.push(command)
     }
+
+    return true
   }
 
   addSubcommand (subCommand) {


### PR DESCRIPTION
### Before
`[Commands] undefined champion failed to load - Required API wrapper "lol" not found.`
`[Commands] undefined love failed to load - Required environment variable "DASHBOARD_URL" is not set.`

### After
`[Commands] leagueoflegends champion failed to load - Couldn't find parent command.`
`[Commands] lastfm love failed to load - Required environment variable "DASHBOARD_URL" is not set.`