### PR TITLE
Self-assignable roles + Reaction roles

### DIFF
--- a/src/commands/utility/sendembed.js
+++ b/src/commands/utility/sendembed.js
@@ -1,0 +1,28 @@
+const { Command, SwitchbladeEmbed } = require('../../')
+
+module.exports = class SendEmbed extends Command {
+  constructor (client) {
+    super(client, {
+      name: 'sendembed',
+      aliases: ['embed'],
+      category: 'utility',
+      parameters: [{
+        type: 'string', full: true, required: false
+      }, [{
+        type: 'string', name: 'title', aliases: ['t']
+      }, {
+        type: 'string', name: 'description', aliases: ['d']
+      }, {
+        type: 'string', name: 'color', aliases: ['c']
+      }]]
+    })
+  }
+
+  run ({ t, author, channel, flags }, data) {
+    let embed = new SwitchbladeEmbed({data: JSON.parse(data)})
+    if (flags.title) embed.setTitle(flags.title)
+    if (flags.description) embed.setDescription(flags.description)
+    if (flags.color) embed.setColor(flags.color)
+    channel.send(embed)
+  }
+}


### PR DESCRIPTION
- [ ] **Self-assignable roles** Closes #110
  - [ ] **Configurable:** Required roles to get a role (require all configured roles/require one of the configured roles)
  - [ ] **Configurable:** Roles that cant't get that role
  - [ ] `s!role` - Gives you a self-assignable role
    - Possible aliases: `s!iam`, `s!selfrole`, `s!getrole`
  - [ ] **Grouping**
    - [ ] **Configurable:** Maximum amount of roles a user can obtain from that group
    - [ ] **Configurable:** Wether to remove other roles from the same group when a user obtains a new one (remove the oldest assigned one in a group with maximum > 1)
    - [ ] **Configurable:** Required roles to get a role from that group (require all configured roles/require one of the configured roles)
    - [ ] **Configurable:** Roles that cant't get roles from that group
- [ ]  **Reaction roles** Closes #301
  - [ ] Add role to user when they add a reaction
  - [ ] Remove role from user when they remove said reaction (maybe make this behaviour configurable?)
  - [ ] `s!reactionrole` - Configures a reaction role on a message
- [x] `s!sendembed` - Sends an embed
- [ ] `s!editembed` - Edits an embed sent with `s!sendembed`