### PR TITLE
Adding games category for Minecraft subcommands

### DIFF
--- a/src/commands/games/minecraft/namehistory.js
+++ b/src/commands/games/minecraft/namehistory.js
@@ -8,6 +8,7 @@ module.exports = class MinecraftNameHistory extends Command {
     super(client, {
       name: 'namehistory',
       aliases: ['nameh', 'nh'],
+      category: 'games',
       parentCommand: 'minecraft',
       parameters: [{
         type: 'string',

--- a/src/commands/games/minecraft/server.js
+++ b/src/commands/games/minecraft/server.js
@@ -9,6 +9,7 @@ module.exports = class MinecraftServer extends Command {
     super(client, {
       name: 'server',
       aliases: ['sv'],
+      category: 'games',
       parentCommand: 'minecraft',
       parameters: [{
         type: 'string',

--- a/src/commands/games/minecraft/skin.js
+++ b/src/commands/games/minecraft/skin.js
@@ -8,6 +8,7 @@ module.exports = class MinecraftSkin extends Command {
     super(client, {
       name: 'skin',
       aliases: ['minecraftskin', 'mskin', 's'],
+      category: 'games',
       parentCommand: 'minecraft',
       parameters: [{
         type: 'string',


### PR DESCRIPTION
Minecraft subcommands should have the `games` category like it's parent.