### PR TITLE
Add 5s nodemon reload delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
   "nodemonConfig": {
     "ignore": [
       "locales/*"
-    ]
+    ],
+    "delay": "5000"
   },
   "optionalDependencies": {
     "@discordjs/uws": "^11.149.1",


### PR DESCRIPTION
When checking out branches to test Pull Requests, sometimes nodemon will reload the bot multiple times in the span of a few seconds, ultimately causing the bot's daily identify limit to be exceeded. This PR attempts to fix that by adding a 5 second delay between nodemon reloads.