### PR TITLE
Disable Google Safe Search if channel is marked as nsfw

### DIFF
--- a/src/apis/GoogleSearch.js
+++ b/src/apis/GoogleSearch.js
@@ -9,13 +9,13 @@ module.exports = class CrowdinAPI extends APIWrapper {
     })
   }
 
-  async search (query) {
-    return fetch(`https://www.googleapis.com/customsearch/v1?q=${query}&key=${process.env.G_CSE_CREDENTIALS}&cx=${process.env.G_CSE_ID}&safe=active`)
+  async search (query, useSafeSearch = true) {
+    return fetch(`https://www.googleapis.com/customsearch/v1?q=${query}&key=${process.env.G_CSE_CREDENTIALS}&cx=${process.env.G_CSE_ID}&safe=${useSafeSearch ? 'active' : 'off'}`)
       .then(r => r.json())
   }
 
-  async searchImage (query) {
-    return fetch(`https://www.googleapis.com/customsearch/v1?q=${query}&key=${process.env.G_CSE_CREDENTIALS}&cx=${process.env.G_CSE_ID}&safe=active&searchType=image`)
+  async searchImage (query, useSafeSearch = true) {
+    return fetch(`https://www.googleapis.com/customsearch/v1?q=${query}&key=${process.env.G_CSE_CREDENTIALS}&cx=${process.env.G_CSE_ID}&safe=${useSafeSearch ? 'active' : 'off'}&searchType=image`)
       .then(r => r.json())
   }
 }

--- a/src/commands/misc/google.js
+++ b/src/commands/misc/google.js
@@ -13,8 +13,8 @@ module.exports = class GoogleCommand extends SearchCommand {
     }, client)
   }
 
-  async search (_, query) {
-    const { items } = await this.client.apis.gsearch.search(query)
+  async search ({ channel }, query) {
+    const { items } = await this.client.apis.gsearch.search(query, channel.nsfw)
     return items
   }
 

--- a/src/commands/misc/image.js
+++ b/src/commands/misc/image.js
@@ -15,7 +15,7 @@ module.exports = class ImageSearchCommand extends Command {
 
   async run ({ t, channel }, query) {
     try {
-      const image = await this.client.apis.gsearch.searchImage(query)
+      const image = await this.client.apis.gsearch.searchImage(query, channel.nsfw)
       if (image.items) {
         return channel.send(image.items[0].link)
       } else {


### PR DESCRIPTION
Disables Safe Search for the `image` and `google` commands depending on whether the text channel is marked as not safe for work.